### PR TITLE
Do not compile in the xposed API. It now causes xposed to reject the module.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,6 @@ android {
 }
 
 dependencies {
-    provided 'de.robv.android.xposed:api:54'
+    provided 'de.robv.android.xposed:api:53'
     compile 'com.android.support:appcompat-v7:22.2.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    provided 'de.robv.android.xposed:api:54'
     compile 'com.android.support:appcompat-v7:22.2.0'
-    compile files('libs/XposedBridgeApi-54.jar')
 }


### PR DESCRIPTION
This is the correct method.